### PR TITLE
feat/shxm 119 api start game

### DIFF
--- a/features/start_game.feature
+++ b/features/start_game.feature
@@ -1,0 +1,80 @@
+Feature: Iniciar partida de juego SHXL
+  Como anfitrión de una sala de juego
+  Quiero poder iniciar la partida cuando estén todos listos
+  Para que comience la fase de juego con roles asignados
+
+  Background:
+    Given el servidor de juego está en funcionamiento
+
+  # Scenarios de inicio exitoso
+  Scenario: Iniciar partida exitosamente con jugadores suficientes
+    Given existe una sala de juego con 8 lugares máximos
+    And se han unido 5 jugadores a la sala
+    When el anfitrión envía una petición POST para iniciar la partida
+    Then el sistema responde con estado 200
+    And el cuerpo contiene state "in_progress"
+    And el cuerpo contiene roles_assigned true
+    And el cuerpo contiene deck_ready true
+    And el cuerpo contiene currentPlayers mayor a 4
+
+  Scenario: Iniciar partida llenando sala con jugadores AI
+    Given existe una sala de juego con 6 lugares máximos
+    And se han unido 5 jugadores a la sala
+    When el anfitrión envía una petición POST para iniciar la partida
+    Then el sistema responde con estado 200
+    And el cuerpo contiene state "in_progress"
+    And el cuerpo contiene currentPlayers igual a 6
+
+  # Scenarios de validación de jugadores
+  Scenario: Rechazar inicio con pocos jugadores
+    Given existe una sala de juego con 8 lugares máximos
+    And se han unido 2 jugadores a la sala
+    When el anfitrión envía una petición POST para iniciar la partida
+    Then el sistema responde con estado 403
+    And el cuerpo contiene error "Need at least 5 players to start"
+
+  Scenario: Rechazar inicio con sala vacía
+    Given existe una sala de juego con 8 lugares máximos
+    When el anfitrión envía una petición POST para iniciar la partida
+    Then el sistema responde con estado 403
+    And el cuerpo contiene error "No players in the game"
+
+  # Scenarios de validación de permisos
+  Scenario: Rechazar inicio si no eres el anfitrión
+    Given existe una sala de juego con 8 lugares máximos
+    And se han unido 6 jugadores a la sala
+    When un jugador no-anfitrión envía una petición POST para iniciar la partida
+    Then el sistema responde con estado 403
+    And el cuerpo contiene error "Only the host can start the game"
+
+  Scenario: Rechazar inicio con hostPlayerID faltante
+    Given existe una sala de juego con 8 lugares máximos
+    And se han unido 5 jugadores a la sala
+    When se envía una petición POST sin hostPlayerID para iniciar la partida
+    Then el sistema responde con estado 400
+    And el cuerpo contiene error "Missing hostPlayerID"
+
+  # Scenarios de estado del juego
+  Scenario: Rechazar inicio de partida ya iniciada
+    Given existe una sala de juego con 8 lugares máximos
+    And se han unido 5 jugadores a la sala
+    And la partida ya ha sido iniciada
+    When el anfitrión envía una petición POST para iniciar la partida
+    Then el sistema responde con estado 403
+    And el cuerpo contiene error "Game already in progress"
+
+  Scenario: Rechazar inicio en sala inexistente
+    When el anfitrión envía una petición POST a /games/invalid123/start
+    Then el sistema responde con estado 404
+    And el cuerpo contiene error "Game not found"
+
+  # Scenario de flujo completo
+  Scenario: Flujo completo - crear sala, agregar jugadores e iniciar
+    When el cliente envía una petición POST a /newgame con 7 jugadores y estrategia "smart"
+    Then el sistema responde con estado 201
+    And el cuerpo contiene un gameID
+    When se unen 5 jugadores adicionales a la sala
+    And el anfitrión envía una petición POST para iniciar la partida
+    Then el sistema responde con estado 200
+    And el cuerpo contiene state "in_progress"
+    And el cuerpo contiene currentPlayers igual a 7

--- a/features/steps/abstract_player_steps.py
+++ b/features/steps/abstract_player_steps.py
@@ -1,6 +1,5 @@
 from unittest.mock import Mock
 
-# mypy: disable-error-code=import
 from behave import given, then, when
 
 from src.game.game_state import EnhancedGameState
@@ -99,11 +98,9 @@ def step_impl_player_with_role_and_party(context, role_name, party):
 @given("un estado de juego con {num_players:d} jugadores")
 def step_impl_create_game_state_for_player(context, num_players):
     """Create a game state with specific number of players."""
-    # Use the real EnhancedGameState instead of a mock
     context.game_state = EnhancedGameState()
     context.players = []
 
-    # Create a mock board for compatibility with existing steps
     context.board = Mock()
     context.board.veto_available = context.game_state.veto_available
     context.board.liberal_track = context.game_state.liberal_track
@@ -367,7 +364,6 @@ def step_impl_check_abstract_method(context, method_name):
     assert hasattr(context.player, method_name)
     method = getattr(context.player, method_name)
     assert callable(method)
-    # For abstract methods, check that they exist in the original Player class
     assert hasattr(Player, method_name)
     original_method = getattr(Player, method_name)
     assert getattr(original_method, "__isabstractmethod__", False)

--- a/features/steps/abstract_power_steps.py
+++ b/features/steps/abstract_power_steps.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-# mypy: disable-error-code=import
 from behave import given, then, when
 
 from src.game.powers.abstract_power import (

--- a/src/game/board.py
+++ b/src/game/board.py
@@ -1,6 +1,5 @@
 from random import shuffle
 
-# !This can be used to balance the game
 VETO_POWER_THRESHOLD = 5
 
 
@@ -20,23 +19,19 @@ class GameBoard(object):
         self.player_count = player_count
         self.with_communists = with_communists
 
-        # Initialize policy trackers
-        self.liberal_track_size = 5  # Default size
-        self.fascist_track_size = 6  # Always 6
+        self.liberal_track_size = 5
+        self.fascist_track_size = 6
         self.communist_track_size = self._get_communist_track_size()
 
-        # Initialize policy counts
         self.liberal_track = 0
         self.fascist_track = 0
         self.communist_track = 0
         self.policies = []
         self.discards = []
 
-        # Set up power slots based on player count
         self.fascist_powers = self._setup_fascist_powers()
         self.communist_powers = self._setup_communist_powers()
 
-        # Store Veto flag, which becomes available after 5 fascist policies
         self.veto_available = False
 
     def _get_communist_track_size(self):
@@ -121,19 +116,15 @@ class GameBoard(object):
             list: List of drawn policies
         """
 
-        # If there are not enough policies to be drawn, shuffle the remaining policies with the discard pile
         if len(self.policies) < count:
-            # Add the discard pile into the draw pile
             self.policies.extend(self.discards)
             self.discards = []
             shuffle(self.policies)
 
-        # Draw policies one by one to ensure they're unique objects
         drawn = []
         for _ in range(count):
             drawn.append(self.policies.pop(0))
 
-        # Chaos policies
         if count > 1:
             print("Drawing chaos policy")
 
@@ -172,30 +163,23 @@ class GameBoard(object):
         elif policy_type == "fascist":
             self.fascist_track += 1
 
-            # Sync the game state's fascist track with the board's
             self.state.fascist_track = self.fascist_track
 
-            # Check for power
             power = self.get_fascist_power() if not chaos else None
 
-            # Check for win
             if self.fascist_track >= self.fascist_track_size:
                 self.state.game_over = True
                 self.state.winner = "fascist"
 
-            # Check for veto power
             if self.fascist_track >= VETO_POWER_THRESHOLD:
                 self.veto_available = True
 
         elif policy_type == "communist":
             self.communist_track += 1
 
-            # Sync the game state's fascist track with the board's
             self.state.communist_track = self.communist_track
 
-            # Check for power
             power = self.get_communist_power() if not chaos else None
-            # Check for win
             if (
                 self.communist_track >= self.communist_track_size
                 and self.communist_track_size > 0
@@ -205,37 +189,29 @@ class GameBoard(object):
 
         if antipolicies is True:
             if policy_type == "antifascist":
-                # Goes on communist track, removes a fascist policy
                 self.communist_track += 1
                 if self.fascist_track > 0:
                     self.fascist_track -= 1
 
-                    # Sync the game state's fascist track with the board's
                     self.state.fascist_track = self.fascist_track
 
                     if self.fascist_track < VETO_POWER_THRESHOLD:
                         self.veto_available = False
 
-                # Block next fascist power
                 self.state.block_next_fascist_power = True
 
             elif policy_type == "anticommunist":
-                # Goes on fascist track, removes a communist policy
                 self.fascist_track += 1
 
-                # Sync the game state's fascist track with the board's
                 self.state.fascist_track = self.fascist_track
 
                 if self.communist_track > 0:
                     self.communist_track -= 1
 
-                # Block next communist power
                 self.state.block_next_communist_power = True
 
             elif policy_type == "socialdemocratic":
-                # Goes on liberal track, removes fascist or communist policy
                 self.liberal_track += 1
-                # Chancellor chooses which policy to remove
                 remove = self.state.chancellor.social_democratic_removal_choice(
                     self.state
                 )
@@ -243,7 +219,6 @@ class GameBoard(object):
                     if self.fascist_track > 0:
                         self.fascist_track -= 1
 
-                    # Sync the game state's fascist track with the board's
                     self.state.fascist_track = self.fascist_track
 
                     if self.fascist_track < VETO_POWER_THRESHOLD:
@@ -257,23 +232,18 @@ class GameBoard(object):
 
         if emergency is True:
             if policy_type == "article48":
-                # President executes Article 48 powers
                 print(
                     f"President {self.state.president.name} executed Article 48 powers."
                 )
             elif policy_type == "enablingact":
-                # Chancellor executes Enabling Act powers
                 print(
                     f"Chancellor {self.state.chancellor.name} executed Enabling Act powers."
                 )
 
-        # Store the most recently enacted policy
         self.state.most_recent_policy = policy
 
-        # Track the policy enactment for statistics
         if not hasattr(self.state, "policy_history"):
             self.state.policy_history = []
-        # Record this policy enactment
         self.state.policy_history.append(
             {
                 "policy": policy_type,
@@ -298,7 +268,6 @@ class GameBoard(object):
         Returns:
             str or None: The power to use
         """
-        # Check if power should be blocked
         if self.state.block_next_fascist_power:
             self.state.block_next_fascist_power = False
             return None
@@ -314,7 +283,6 @@ class GameBoard(object):
         Returns:
             str or None: The power to use
         """
-        # Check if power should be blocked
         if self.state.block_next_communist_power:
             self.state.block_next_communist_power = False
             return None

--- a/src/game/phases/election.py
+++ b/src/game/phases/election.py
@@ -43,8 +43,8 @@ class ElectionPhase(GamePhase):
             - Term limit resets
             - Election tracker management
         """
-        # from src.game.phases.gameover import GameOverPhase
-        # from src.game.phases.legislative import LegislativePhase
+        from src.game.phases.gameover import GameOverPhase
+        from src.game.phases.legislative import LegislativePhase
 
         self._check_marked_for_execution()
 

--- a/src/game/phases/legislative.py
+++ b/src/game/phases/legislative.py
@@ -6,8 +6,8 @@ actions in the game.
 """
 
 from src.game.phases.abstract_phase import GamePhase
-
-# from src.game.phases.gameover import GameOverPhase
+from src.game.phases.election import ElectionPhase
+from src.game.phases.gameover import GameOverPhase
 
 
 class LegislativePhase(GamePhase):
@@ -43,7 +43,6 @@ class LegislativePhase(GamePhase):
                 - ElectionPhase: If veto succeeds or normal turn progression
                 - GameOverPhase: If win condition is met or Hitler is executed
         """
-        from src.game.phases.election import ElectionPhase
 
         policies = self.game.state.board.draw_policy(3)
 


### PR DESCRIPTION
### **TL;DR**

Esta PR implementa el endpoint `POST /games/<gameId>/start`, permitiendo al anfitrión iniciar la partida. Valida mínimo de jugadores y permisos de host, asigna roles automáticamente, construye el mazo de políticas, cambia el estado de la sala a `in_progress` y rellena con jugadores IA si es necesario. Incluye escenarios de pruebas BDD exhaustivos y maneja todos los casos de validación y errores.

---

### Tipo de cambio

* [x] `feat:` ✨ Nueva funcionalidad (agrega endpoint para iniciar partidas y lógica de setup)

---

### **Descripción**

#### 🚦 Endpoint de inicio de partida (`/games/<gameId>/start`)

- Permite al anfitrión iniciar una partida existente usando un request HTTP POST.
- Valida que haya al menos 5 jugadores y que la solicitud provenga del jugador host.
- Asigna automáticamente roles a todos los jugadores, construye el mazo de políticas y prepara el estado inicial.
- Cambia el estado de la sala a `in_progress` una vez que el setup es exitoso.
- Si faltan jugadores para el mínimo requerido, agrega bots/IA para completar el cupo.
- Maneja todos los casos de validación y errores, devolviendo mensajes claros y consistentes al cliente.

#### ✅ Pruebas BDD

- **Archivo feature**: `start_game.feature`
- **Steps**: `start_game_steps.py`
- Cubre:
  - Inicio exitoso con host y jugadores válidos
  - Errores por host inválido o sala en estado incorrecto
  - Validación de mínimo de jugadores
  - Auto-relleno con bots y setup automático de roles y mazo

#### 🔧 Mecánicas internas

- Lógica modular para asignación de roles y construcción del mazo.
- Control estricto de permisos del host y estado de la partida.
- Respuestas uniformes y validación detallada para cualquier edge case.

---

### Objetivo

Permitir el inicio formal de partidas bajo reglas y validaciones estrictas, asegurando un setup coherente y automático para todos los jugadores, ya sean humanos o IA. Deja la sala lista para comenzar la fase de juego con todos los recursos necesarios y controlando errores desde el backend.

---

### Checklist

* [x] Endpoint `POST /games/<gameId>/start` implementado y probado
* [x] Validación de permisos y mínimo de jugadores
* [x] Asignación automática de roles y creación del mazo de políticas
* [x] Estado de sala actualizado a `in_progress`
* [x] Auto-completado con bots si falta
* [x] Pruebas BDD y unitarias de todos los escenarios posibles

---

### Testing

* [x] Escenarios Behave para inicio de partida (`behave features/start_game.feature`)

---

### 💬 Notas adicionales

* El endpoint está listo para integración con UI, bots o sistemas de orquestación de partidas.
* Maneja casos de edge como intento de inicio por jugadores no anfitriones o con cantidad insuficiente de participantes.
* Documentación lista para extensión y futuras features.

---

### 🔗 Issues relacionados / Cierra

* Closes #89 

---

### 📂 Rama destino

`develop`
